### PR TITLE
plain-text password hotfix

### DIFF
--- a/lib/db.js
+++ b/lib/db.js
@@ -50,7 +50,7 @@ const createUserWebsite = async (uid, data) => {
 };
 
 const createUser = async (data) => {
-  return new User({ password: hash(data.password), ...data }).save();
+  return new User({ ...data, password: hash(data.password) }).save();
 };
 
 const updateUser = async (id, data) => {


### PR DESCRIPTION
Was getting log-in errors, and traced back to the initial user creation steps. Plain text passwords are saved to the database. Thus, hashed passwords and plain text passwords never matched during auth check.
[Related commit](https://github.com/useaurora/api/commit/b3e21c5c17f172933cd2668183a4da40a855ea9e#comments)

Simple fix:
```
return await new User({ ...data, password: hash(data.password) }).save();
